### PR TITLE
Update initializer

### DIFF
--- a/mat-ripple.js
+++ b/mat-ripple.js
@@ -1,55 +1,51 @@
 import Ripple from './Ripple.js';
 
-const rTargets = document.querySelectorAll('[ripple]');
-	
 function readyToRemove(e, ripple) {
 	if (!ripple) return;
-	if (e.target.getAttribute('ripple') === null) return false;
+	if (!e.target.closest('[ripple]')) return false;
 	return ripple.readyToRemove = true;
 }
 
-rTargets.forEach(target => {
-	let ripple;
+let ripple;
 
-	target.addEventListener('contextmenu', e => {
-		if (e.target.nodeName !== 'A') e.preventDefault();
-	});
+document.body.addEventListener('pointerdown', e => {
+	// Only use ripple targets.
+	if (e.target.getAttribute('ripple') === null) return;
+	const target = e.target.closest('[ripple]');
 	
-	target.addEventListener('pointerdown', e => {
-		// Filter out child elements
-		if (e.target.getAttribute('ripple') === null) return;
-
-		// Set position
-		const rData = {
-			position: {
-				x: e.layerX,
-				y: e.layerY
-			}
+	// Set position.
+	const rData = {
+		position: {
+			x: e.layerX,
+			y: e.layerY
 		}
-		
-		// Set color
-		rData.color = e.target.getAttribute('ripple-color') || undefined;
-    
-		// Handle icons
-		if (e.target.getAttribute('ripple-icon') !== null) {
-			rData.position = {x:e.target.offsetWidth / 2,y:e.target.offsetHeight / 2}
-			rData.size = Math.max.apply(null, [e.target.offsetWidth, e.target.offsetHeight]) * 1.25;
-			rData.timeout = 200;
-			return ripple = new Ripple({target, ...rData});
-		};
-		
-		// Calculate pixel offset from center of element
-		const offsetX = Math.abs((e.target.offsetWidth / 2) - rData.position.x);
-		const offsetY = Math.abs((e.target.offsetHeight / 2) - rData.position.y);
-		const offsetH = Math.hypot(offsetX, offsetY);
-		
-		// Set size based on element hypotenuse & pixel offset
-		rData.size = Math.hypot(e.target.offsetWidth, e.target.offsetHeight) + (offsetH * 2);
-    
-		// Create ripple
-		ripple = new Ripple({target, ...rData});
-	});
+	};
 
-	target.addEventListener('pointerup', e => readyToRemove(e, ripple));
-	target.addEventListener('pointerleave', e => readyToRemove(e, ripple));
+	// Set color.
+	rData.color = target.getAttribute('ripple-color') || undefined;
+
+	// Handle icons.
+	if (target.getAttribute('ripple-icon') !== null) {
+		rData.position = {
+			x: target.offsetWidth / 2,
+			y: target.offsetHeight / 2
+		};
+		rData.size = Math.max.apply(null, [target.offsetWidth, target.offsetHeight]) * 1.25;
+		rData.timeout = 200;
+		return ripple = new Ripple({target: target, ...rData});
+	};
+
+	// Calculate pixel offset from center of element.
+	const offsetX = Math.abs((target.offsetWidth / 2) - rData.position.x);
+	const offsetY = Math.abs((target.offsetHeight / 2) - rData.position.y);
+	const offsetH = Math.hypot(offsetX, offsetY);
+
+	// Set size based on element hypotenuse & pixel offset.
+	rData.size = Math.hypot(target.offsetWidth, target.offsetHeight) + (offsetH * 2);
+
+	// Create ripple
+	ripple = new Ripple({target: target, ...rData});
 });
+
+document.body.addEventListener('pointerup', e => readyToRemove(e, ripple));
+document.body.addEventListener('pointerleave', e => readyToRemove(e, ripple), {capture: true});


### PR DESCRIPTION
Use one event listener on the document rather than creating a listener for each ripple element on the page. This helps when dynamically adding ripple elements after the init script has run.